### PR TITLE
do not buffer entire stream when starting from beginning

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "prettier-bytes": "^1.0.4",
     "pretty-ms": "^5.0.0",
     "pump": "^3.0.0",
+    "streamx": "^2.6.4",
     "thunky": "^1.1.0",
     "webm-cluster-stream": "^1.0.0"
   },


### PR DESCRIPTION
Currently the feed download selection will aggresively download the entire stream when watching from the beginning.
This changes it to only download ~120seconds in front of what you are watching for better scaling/perf