### PR TITLE
Free streams swarm with each other

### DIFF
--- a/components/broadcast.js
+++ b/components/broadcast.js
@@ -115,6 +115,7 @@ module.exports = class Broadcast extends Component {
     this.timeout = null
     this.recording = null
     this._server = null
+    this.swarm = null
     this.uploadedBytes = 0
     this._uploaded = html`
       <span>0 B</span>
@@ -227,6 +228,7 @@ module.exports = class Broadcast extends Component {
     video.src = ''
 
     if (this.swarm) this.swarm.destroy()
+
     this.seller.feed.close(() => {
       this._server.close()
       this._server.on('close', () => {

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ function broadcast () {
         const seller = dazaar.sell(feed, {
           validate (remoteKey, done) {
             console.log('validate', remoteKey, payment)
-            if (!payment) return done(null, { type: 'free' })
+            if (!payment) return done(null, { type: 'free', uniqueFeed: seller.uniqueFeed })
             pay.validate(remoteKey, function (err, info) {
               console.log('done', err, info)
               done(err, info)
@@ -194,6 +194,7 @@ function broadcast () {
         })
 
         if (payment) dazaar.setConfig(payment.currency, config)
+        else seller.uniqueFeed = false
 
         seller.ready(function () {
           if (payment) pay = new Payment(seller, payment, config)

--- a/lib/peer-swarm.js
+++ b/lib/peer-swarm.js
@@ -1,0 +1,12 @@
+module.exports = function (feed) {
+  return require('@hyperswarm/replicator')(feed, {
+    live: true,
+    lookup: true,
+    announce: true,
+    onstream (protocol, info) {
+      protocol.on('handshake', function () {
+        info.deduplicate(protocol.publicKey, protocol.remotePublicKey)
+      })
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@dazaar/payment-lightning": "^1.1.0",
-    "@hyperswarm/replicator": "^1.7.0",
+    "@hyperswarm/replicator": "^1.7.1",
     "@mafintosh/search-component": "^1.0.1",
     "crypto-payment-url": "^1.0.2",
     "dazaar": "^1.0.1",


### PR DESCRIPTION
This disables the unique feed generation we use to verify payments on free stream, allowing viewers to swarm with other each to replicate the content.

Buyers still contact the seller first as the bootstrap process.
Only downside is that if the seller changes a free stream to a paid one, they'll get a new unique feed but technically we can add the content from the non unique one since it has the same merkle tree (future iteration)